### PR TITLE
xinput-calibrator: update source uri

### DIFF
--- a/recipes/xorg-app/xinput-calibrator_0.7.5.oe
+++ b/recipes/xorg-app/xinput-calibrator_0.7.5.oe
@@ -4,7 +4,7 @@ LICENSE = "MIT/X11"
 
 require xorg-app-common.inc
 
-SRC_URI = "http://github.com/downloads/tias/xinput_calibrator/xinput_calibrator-${PV}.tar.gz"
+SRC_URI = "http://repository.timesys.com/buildsources/x/xinput_calibrator/xinput_calibrator-${PV}/xinput_calibrator-${PV}.tar.gz"
 SRC_URI += "file://calib_once.patch"
 
 S = "${SRCDIR}/xinput_calibrator-${PV}"


### PR DESCRIPTION
The github download page has vanished, so move to a repository from
timesys. Future updates should use the github releases page, but is
ships different checksums.